### PR TITLE
compile files only if they have been changed

### DIFF
--- a/src/main/java/com/dasberg/maven/plugins/ClosureCompilerMojo.java
+++ b/src/main/java/com/dasberg/maven/plugins/ClosureCompilerMojo.java
@@ -64,15 +64,19 @@ public class ClosureCompilerMojo extends AbstractMojo {
         final String fileName = js.getName();
         final String target = targetPath(useVersion, fileName);
         final String source = sourcePath(js);
-        final ClosureCompilerRunner runner = new ClosureCompilerRunner(compilation_level, source, target);
-        if (runner.shouldRunCompiler()) {
-            try {
-                runner.run();
-            } catch (SecurityException e) {
-                // expected throw when run finishes it calls System.exit.
-            }
+        if (js.lastModified() > new File(target).lastModified()) {
+	        final ClosureCompilerRunner runner = new ClosureCompilerRunner(compilation_level, source, target);
+	        if (runner.shouldRunCompiler()) {
+	            try {
+	                runner.run();
+	            } catch (SecurityException e) {
+	                // expected throw when run finishes it calls System.exit.
+	            }
+	        }
+	        getLog().debug("Compiled file: " + source + " to file: " + target);
+        } else {
+	        getLog().debug("Skipped file because not modified: " + source);
         }
-        getLog().debug("Compiled file: " + source + " to file: " + target);
     }
 
     /**


### PR DESCRIPTION
Hi, this is a change to make the plugin only compile files if they have been changed. This is especially useful when using Maven integration inside of Eclipse, preventing incremental builds from recompiling files when not necessary.

Legal mumbojumbo: I hereby state that I am the author of 100% of the changes, that I do own the copyright to those changes, and that I do have the right to contribute the changes to you.
